### PR TITLE
avoid trigger CI with changes on text files

### DIFF
--- a/.github/workflows/env-build.yaml
+++ b/.github/workflows/env-build.yaml
@@ -23,8 +23,10 @@ jobs:
         uses: tj-actions/changed-files@v37
         with:
           files_ignore: |
-            .github/workflows/env-build.yaml
+            .github/**
             **/README.md
+            LICENSE
+            *.md
           dir_names: "true"
           dir_names_exclude_current_dir: "true"
           


### PR DESCRIPTION
including CODEOWNERS, LICENSE and any *.md file

after the run of https://github.com/vre-hub/environments/actions/runs/5759869330/job/15614741712 giving as an output:
`The final list is: [".github"]`