### PR TITLE
Add ET user environment

### DIFF
--- a/vre-singleuser-et/.gitignore
+++ b/vre-singleuser-et/.gitignore
@@ -1,0 +1,5 @@
+Dockerfile_dev
+Dockerfile_py311
+configure-vre.py
+configure-vre.sh
+voms/

--- a/vre-singleuser-et/Dockerfile
+++ b/vre-singleuser-et/Dockerfile
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE=ghcr.io/vre-hub/vre-singleuser-py311:latest
+FROM ${BASE_IMAGE}
+LABEL author="Paul Laycock"
+LABEL maintainer="Paul Laycock <paul.laycock@unige.ch>"
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+USER root
+RUN python -m pip install --upgrade pip \
+    && python -m pip install nopayloaddb-client==0.3.0
+
+USER $NB_UID


### PR DESCRIPTION
Minimal Dockerfile just adds the nopayloaddb-client package - we can likely merge that to the py311 environment when happy and consider retiring this environment, but this gives us some flexibility to develop too