### PR TITLE
Attempt to add multi-platform builds (copilot-agogo)

### DIFF
--- a/.github/workflows/env-build.yaml
+++ b/.github/workflows/env-build.yaml
@@ -77,6 +77,12 @@ jobs:
       - name: Docker Checkout
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the GH Container Registry
         id: login
         uses: docker/login-action@v2.1.0
@@ -104,5 +110,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           build-args: | 
             BUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Developing on a mac, it was painful not to have the arm images and have a working but not working status through emulation..  it would be great to at least have the py311 base image have a cross-platform build, this is intended to be a generic fix